### PR TITLE
Add QoS packet ID buffer for MQTT client

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MQTTESP8266
-version=5.0.1
+version=5.1.0
 author=Petr B.
 maintainer=Petr B.
 sentence=Lightweight MQTT client library for Arduino using ESP8266 AT command firmware.

--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -50,7 +50,7 @@ static void MQTTClient::DataReceived(uint8_t* data, int length)
         return;
       }
       qosBufferPacketIds[qosBufferHead] = packetId;
-      qosBufferHead = (qosBufferHead + 1) % 10;
+      qosBufferHead = (qosBufferHead + 1) % qosBufferLength;
       qosBufferCount++;
       payloadOffset += 2;
     }
@@ -359,7 +359,7 @@ bool MQTTClient::Loop()
     while(qosBufferHead != qosBufferTail)
     { 
       sendPubAck(qosBufferPacketIds[qosBufferTail]);
-      qosBufferTail = (qosBufferTail + 1) % 10;
+      qosBufferTail = (qosBufferTail + 1) % qosBufferLength;
       qosBufferCount--;
     }
     if(fullQoSBuffer)

--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -84,6 +84,9 @@ bool MQTTClient::Connect(MQTTConnectData mqttConnectData)
 {
   this->client->TCPConnect(mqttConnectData.url, mqttConnectData.port);
   this->keepAlive = mqttConnectData.keepAlive;
+  fullQoSBuffer = false;
+  qosBufferHead = qosBufferTail = 0;
+  qosBufferCount = 0;
   return this->Login(mqttConnectData);
 }
 

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -76,12 +76,17 @@ class MQTTClient
     bool isConnected = false;
     static bool suback;
     static bool connack;
-    static uint16_t packetId;
+    static uint16_t* qosBufferPacketIds;
+    static uint8_t qosBufferHead;
+    static uint8_t qosBufferTail;
+    static uint8_t qosBufferCount;
+    static bool fullQoSBuffer;
+    static uint8_t qosBufferLength;
 
     void sendPubAck(uint16_t packetId);
     
   public:
-    MQTTClient(EspDrv *espDriver, void(*callback)(char* topic, uint8_t* payload, uint16_t plength));
+    MQTTClient(EspDrv *espDriver, void(*callback)(char* topic, uint8_t* payload, uint16_t plength), uint8_t pQosBufferLength = 16);
     bool Connect(MQTTConnectData mQTTConnectData);
     void Disconnect();
     void Subscribe(const char* topic);


### PR DESCRIPTION
Introduces a circular buffer to store QoS packet IDs for improved handling of incoming QoS messages. The buffer size is configurable via the constructor, and the client will close the connection if the buffer overflows. Updates version to 5.1.0.